### PR TITLE
Update nccl.py for TF 2.11's DTensor.

### DIFF
--- a/nccl.py
+++ b/nccl.py
@@ -11,17 +11,17 @@ import time
 import argparse
 import numpy as np
 
-layers = tf.keras.layers
+os.environ['DTENSOR_GPU_USE_NCCL_COMMUNICATION'] = '1'
 
-from tensorflow.python.eager import context
-context.context().configure_collective_ops(use_nccl_communication=True)
+layers = tf.keras.layers
 
 gpus = tf.config.list_physical_devices('GPU')
 if gpus:
   for gpu in gpus:
     tf.config.experimental.set_memory_growth(gpu, True)
-  logical_gpus = tf.config.list_logical_devices('GPU')
-  print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
+
+  print(len(gpus), "Physical GPUs,", dtensor.num_local_devices('GPU'), "Logical GPUs")
+  dtensor.initialize_accelerator_system('GPU')
 
 def parse_cmdline(init_vals):
   f = argparse.ArgumentDefaultsHelpFormatter

--- a/nccl.py
+++ b/nccl.py
@@ -20,7 +20,7 @@ if gpus:
   for gpu in gpus:
     tf.config.experimental.set_memory_growth(gpu, True)
 
-  print(len(gpus), "Physical GPUs,", dtensor.num_local_devices('GPU'), "Logical GPUs")
+  print(len(gpus), "Physical GPUs,", dtensor.num_local_devices('GPU'), "Configured Local GPUs")
   dtensor.initialize_accelerator_system('GPU')
 
 def parse_cmdline(init_vals):


### PR DESCRIPTION
I checked with NCCL_DEBUG=INFO that NCCL communicator is indeed used. The training speed is 

```
gpu-feyu:68214:69504 [2] NCCL INFO comm 0x7f15d0003b10 rank 2 nranks 8 cudaDev 2 busId 60 - Init COMPLETE
gpu-feyu:68214:69508 [6] NCCL INFO comm 0x7f15e4003b10 rank 6 nranks 8 cudaDev 6 busId a0 - Init COMPLETE
gpu-feyu:68214:69509 [7] NCCL INFO comm 0x7f15e0003b10 rank 7 nranks 8 cudaDev 7 busId b0 - Init COMPLETE
gpu-feyu:68214:69505 [3] NCCL INFO comm 0x7f15cc003b10 rank 3 nranks 8 cudaDev 3 busId 70 - Init COMPLETE
gpu-feyu:68214:69506 [4] NCCL INFO comm 0x7f15d4003b10 rank 4 nranks 8 cudaDev 4 busId 80 - Init COMPLETE
gpu-feyu:68214:69502 [0] NCCL INFO comm 0x7f15c8003b10 rank 0 nranks 8 cudaDev 0 busId 40 - Init COMPLETE
gpu-feyu:68214:69503 [1] NCCL INFO comm 0x7f15c4003b10 rank 1 nranks 8 cudaDev 1 busId 50 - Init COMPLETE
gpu-feyu:68214:69507 [5] NCCL INFO comm 0x7f15d8003b10 rank 5 nranks 8 cudaDev 5 busId 90 - Init COMPLETE

global_step: 10 images_per_sec: 14.3
global_step: 20 images_per_sec: 146.7
global_step: 30 images_per_sec: 147.3
global_step: 40 images_per_sec: 147.1
global_step: 50 images_per_sec: 149.6
global_step: 60 images_per_sec: 147.8
global_step: 70 images_per_sec: 145.1
global_step: 80 images_per_sec: 149.6
global_step: 90 images_per_sec: 152.3
```

This confirms the NCCL OOM bug is fixed. 